### PR TITLE
Convert memoryview to bytes to fix error

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def heic_to_jpg(heic_path):
     image = Image.frombytes(
         heif_file.mode,
         heif_file.size,
-        heif_file.data,
+        bytes(heif_file.data),  # <-- Convert memoryview to bytes here
         "raw",
         heif_file.mode,
         heif_file.stride,


### PR DESCRIPTION
Fixes error:
Traceback (most recent call last):
  File "D:\Downloads\heic-to-jpeg-main\heic-to-jpeg-main\main.py", line 70, in <module>
    convert_dir_heic_to_jpg(args.path, args.replace)
  File "D:\Downloads\heic-to-jpeg-main\heic-to-jpeg-main\main.py", line 54, in convert_dir_heic_to_jpg
    heic_to_jpg(heic_path)
  File "D:\Downloads\heic-to-jpeg-main\heic-to-jpeg-main\main.py", line 17, in heic_to_jpg
    image = Image.frombytes(
            ^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\PIL\Image.py", line 2969, in frombytes
    im.frombytes(data, decoder_name, args)
  File "C:\Python311\Lib\site-packages\PIL\Image.py", line 826, in frombytes
    s = d.decode(data)
        ^^^^^^^^^^^^^^
TypeError: argument 1 must be read-only bytes-like object, not memoryview